### PR TITLE
Molecular Formula Added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `molecular_formula` property
 ### Changed
 - `README.md` updated
-- `molecular_formula` property 
 ## [0.5] - 2025-06-27
 ### Added
 - `delta_h` property 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - `README.md` updated
+- `molecular_formula` property 
 ## [0.5] - 2025-06-27
 ### Added
 - `delta_h` property 

--- a/opr/params.py
+++ b/opr/params.py
@@ -154,3 +154,12 @@ NN_PARAMS = {
     'GC': (-11.1, -0.0267),
     'GG': (-11.0, -0.0266), 
 }
+
+
+MOLECULAR_FORMULA_FORMAT = "C{c_count}H{h_count}N{n_count}O{o_count}P{p_count}"
+MOLECULAR_FORMULA_BASES = {
+    "A": {"C": 10, "H": 13, "N": 5, "O": 3},
+    "T": {"C": 10, "H": 14, "N": 2, "O": 5},
+    "G": {"C": 10, "H": 13, "N": 5, "O": 4},
+    "C": {"C": 9,  "H": 13, "N": 3, "O": 4},
+}

--- a/opr/params.py
+++ b/opr/params.py
@@ -156,7 +156,7 @@ NN_PARAMS = {
 }
 
 
-MOLECULAR_FORMULA_FORMAT = "C{c_count}H{h_count}N{n_count}O{o_count}P{p_count}"
+MOLECULAR_FORMULA_FORMAT_ORDER = ["C", "H", "N", "O", "P"] # CxHyNzOwPv
 MOLECULAR_FORMULA_BASES = {
     "A": {"C": 10, "H": 13, "N": 5, "O": 3},
     "T": {"C": 10, "H": 14, "N": 2, "O": 5},

--- a/opr/primer.py
+++ b/opr/primer.py
@@ -17,7 +17,7 @@ from .params import PRIMER_MELTING_TEMPERATURE_NOT_IMPLEMENTED_ERROR
 from .params import PRIMER_ATTRIBUTE_NOT_COMPUTABLE_ERROR
 from .params import FRAME_ERROR
 from .params import CODONS_TO_AMINO_ACIDS_LONG, CODONS_TO_AMINO_ACIDS_SHORT
-from .params import MOLECULAR_FORMULA_BASES, MOLECULAR_FORMULA_FORMAT
+from .params import MOLECULAR_FORMULA_BASES, MOLECULAR_FORMULA_FORMAT_ORDER
 from .functions import molecular_weight_calc, basic_melting_temperature_calc, salt_adjusted_melting_temperature_calc, gc_clamp_calc
 from .functions import nearest_neighbor_melting_temperature_calc, calculate_thermodynamics_constants
 from .functions import e260_ssnn_calc
@@ -329,13 +329,11 @@ class Primer:
             counts["P"] = len(self._sequence) - 1
             counts["O"] += 2 * (len(self._sequence) - 1)
             counts["H"] -= (len(self._sequence) - 1)
-            self._molecular_formula = MOLECULAR_FORMULA_FORMAT.format(
-                c_count=counts["C"],
-                h_count=counts["H"],
-                n_count=counts["N"],
-                o_count=counts["O"],
-                p_count=counts["P"]
-            )
+            result = []
+            for element in MOLECULAR_FORMULA_FORMAT_ORDER:
+                if counts[element] > 0:
+                    result.append(f"{element}{counts[element]}")
+            self._molecular_formula = ''.join(result)
             self._computed["molecular_formula"] = True
         return self._molecular_formula
 

--- a/opr/primer.py
+++ b/opr/primer.py
@@ -17,6 +17,7 @@ from .params import PRIMER_MELTING_TEMPERATURE_NOT_IMPLEMENTED_ERROR
 from .params import PRIMER_ATTRIBUTE_NOT_COMPUTABLE_ERROR
 from .params import FRAME_ERROR
 from .params import CODONS_TO_AMINO_ACIDS_LONG, CODONS_TO_AMINO_ACIDS_SHORT
+from .params import MOLECULAR_FORMULA_BASES, MOLECULAR_FORMULA_FORMAT
 from .functions import molecular_weight_calc, basic_melting_temperature_calc, salt_adjusted_melting_temperature_calc, gc_clamp_calc
 from .functions import nearest_neighbor_melting_temperature_calc, calculate_thermodynamics_constants
 from .functions import e260_ssnn_calc
@@ -62,6 +63,7 @@ class Primer:
         }
         self._delta_s = None
         self._delta_h = None
+        self._molecular_formula = None
         self._protein_seq = {"AA1": {}, "AA3": {}}
 
         # Track computed attributes
@@ -79,6 +81,7 @@ class Primer:
             },
             "delta_s": False,
             "delta_h": False,
+            "molecular_formula": False,
         }
 
     def is_computed(self, attr: str) -> bool:
@@ -314,6 +317,27 @@ class Primer:
             self._computed["delta_s"] = True
             self._computed["delta_h"] = True
         return self._delta_h
+    
+    @property
+    def molecular_formula(self) -> str:
+        """Calculate the molecular formula and return it."""
+        if not self._computed["molecular_formula"]:
+            counts = {"C": 0, "H": 0, "N": 0, "O": 0, "P": 0}
+            for base in self._sequence:
+                for element, count in MOLECULAR_FORMULA_BASES[base].items():
+                    counts[element] += count
+            counts["P"] = len(self._sequence) - 1
+            counts["O"] += 2 * (len(self._sequence) - 1)
+            counts["H"] -= (len(self._sequence) - 1)
+            self._molecular_formula = MOLECULAR_FORMULA_FORMAT.format(
+                c_count=counts["C"],
+                h_count=counts["H"],
+                n_count=counts["N"],
+                o_count=counts["O"],
+                p_count=counts["P"]
+            )
+            self._computed["molecular_formula"] = True
+        return self._molecular_formula
 
     def repeats(self, sequence: str, consecutive: bool = False) -> int:
         """

--- a/opr/primer.py
+++ b/opr/primer.py
@@ -317,7 +317,7 @@ class Primer:
             self._computed["delta_s"] = True
             self._computed["delta_h"] = True
         return self._delta_h
-    
+
     @property
     def molecular_formula(self) -> str:
         """Calculate the molecular formula and return it."""

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -91,6 +91,16 @@ def test_thermodynamic_constants():
     assert round(delta_h, 1) == round(delta_h_second, 1)
 
 
+def test_molecular_formula():
+    oprimer = Primer("ATCGATCGATCGATCGATCG")
+    assert not oprimer.is_computed("molecular_formula")
+    formula_first = oprimer.molecular_formula
+    assert oprimer.is_computed("molecular_formula")
+
+    formula_second = oprimer.molecular_formula
+    assert formula_first == formula_second
+
+
 def test_to_protein():  # Reference: https://en.vectorbuilder.com/tool/dna-translation.html
     oprimer = Primer("ATCGATCG")
 

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -13,6 +13,21 @@ def test_name():
     assert oprimer.name == "primer1"
 
 
-def test_molecular_formula(): # Reference: https://atdbio.com/tools/oligo-calculator
+def test_molecular_formula1(): # Reference: https://atdbio.com/tools/oligo-calculator
     oprimer = Primer("ATCGGCTAAATCGGCTAA")
     assert oprimer.molecular_formula == "C176H221N70O104P17"
+
+
+def test_molecular_formula2(): # Reference: https://atdbio.com/tools/oligo-calculator
+    oprimer = Primer("AAAAAAAAAAAAAAAAAA")
+    assert oprimer.molecular_formula == "C180H217N90O88P17"
+
+
+def test_molecular_formula3(): # Reference: https://atdbio.com/tools/oligo-calculator
+    oprimer = Primer("ATCG")
+    assert oprimer.molecular_formula == "C39H50N15O22P3"
+
+
+def test_molecular_formula4(): # Reference: https://atdbio.com/tools/oligo-calculator
+    oprimer = Primer("T")
+    assert oprimer.molecular_formula == "C10H14N2O5"

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -13,6 +13,6 @@ def test_name():
     assert oprimer.name == "primer1"
 
 
-def test_molecular_formula(): #Reference: https://atdbio.com/tools/oligo-calculator
+def test_molecular_formula(): # Reference: https://atdbio.com/tools/oligo-calculator
     oprimer = Primer("ATCGGCTAAATCGGCTAA")
     assert oprimer.molecular_formula == "C176H221N70O104P17"

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -11,3 +11,8 @@ def test_sequence():
 def test_name():
     oprimer = Primer("ATCGATCGATCGATCGAT", "primer1")
     assert oprimer.name == "primer1"
+
+
+def test_molecular_formula(): #Reference: https://atdbio.com/tools/oligo-calculator
+    oprimer = Primer("ATCGGCTAAATCGGCTAA")
+    assert oprimer.molecular_formula == "C176H221N70O104P17"


### PR DESCRIPTION
#### Reference Issues/PRs
#3 

#### What does this implement/fix? Explain your changes.
Following #31 and it's closure due to inconsistency in the references, this PR implements one of the selected ways to present the chemical formula of the primer. After a short brainstorm with [ChatGPT](https://chatgpt.com/share/68d0c2d0-3af4-8009-aecd-1b4c143fa725) I realized that it might be better to change the property name to `molecular_formula` rather than `chemical_formula`.

#### Any other comments?
@sepandhaghighi if you have a reference for the formula you sent in the issue, let me know so I can add it to `params.py`.